### PR TITLE
Star spawning rework

### DIFF
--- a/src/lib/CameraMovement.js
+++ b/src/lib/CameraMovement.js
@@ -15,7 +15,7 @@ class CameraMovement extends GameComponentBase {
     }
 
     start() {
-        if (!((window.innerWidth <= 800) && (window.innerHeight <= 600)))
+        if (!(screen && screen.width < 480))
             window.addEventListener('mousemove', this.mouseMove);
     }
 
@@ -77,10 +77,14 @@ class CameraMovement extends GameComponentBase {
 
         this.xSpeed *= this.horSpeedMod;
         this.ySpeed *= this.vertSpeedMod;
-        if (!((window.innerWidth <= 800) && (window.innerHeight <= 600))) {
-            this.camera.position.x += this.xSpeed;
-            this.camera.position.y -= this.ySpeed;
+
+        if (screen && screen.width < 480) {
+            this.xSpeed = 0;
+            this.ySpeed = 0;
         }
+
+        this.camera.position.x += this.xSpeed;
+        this.camera.position.y -= this.ySpeed;
         this.camera.position.z += 0.05;
 
         //console.log(window.innerWidth);

--- a/src/lib/GameWorkIn.svelte
+++ b/src/lib/GameWorkIn.svelte
@@ -29,14 +29,28 @@
     window.addEventListener("resize", sizeWindow);
 
     let mainObject = new GameObject();
-    let backgroundObject = new GameObject();
 
     // give the camera something to output to
     mainObject.addChild(camera);
     mainObject.addChild(new CameraMovement(camera));
-    mainObject.addChild(backgroundObject);
-    mainObject.addChild(new StarManager(camera, 2, mainObject)); // two stars per resolution..... unit? Pixel density?? Idk, it looks good :D
+    mainObject.addChild(new StarManager(camera, 1, mainObject)); // one star per resolution..... unit? Pixel density?? Idk, it looks good :D
     sizeWindow();
+
+
+    // function pausePlay() {
+    //   console.log(window.scrollY + " " + window.innerHeight/2);
+    //   if (window.scrollY > window.innerHeight/2)
+    //   {
+    //     mainObject.setEnabled(false);
+    //     console.log("hitting");
+    //   }
+    //   else
+    //   {
+    //     mainObject.setEnabled(true);
+    //     console.log("hitting 2");
+    //   }
+    // }
+    // window.addEventListener("scroll", pausePlay);
   });
 </script>
     <canvas class="fadeOut position-absolute" bind:this={canvas} />

--- a/src/lib/StarManager.js
+++ b/src/lib/StarManager.js
@@ -9,11 +9,16 @@ class StarManager extends GameComponentBase {
         super();
         this.camera = camera;
         this.activeStars = [];
-        this.starDensity = window.innerWidth * starDensity;
+        this.starDensity = (window.innerWidth + window.innerHeight) * starDensity;
+        this.starterStars = 1000;
+        if ((screen && screen.width < 480))
+        {
+            this.starDensity /= 2;
+            this.starterStars /= 2
+        }
         this.starPool = [];
         this.back = background;
         //this.xFovMod = 0;
-        this.starterStars = 300;
         
     }
 
@@ -22,7 +27,7 @@ class StarManager extends GameComponentBase {
             
             let starVector = this.generateStarVector(this.camera);
             let starSize = 50 * Math.random();
-            let star = new SquareRenderer("white", new Vector3(starVector.x/4, starVector.y/4, Math.pow(2, 5) * Math.random()), starSize, starSize);
+            let star = new SquareRenderer("white", new Vector3(starVector.x/4, starVector.y/4, Math.pow(3, 4) * Math.random()), starSize, starSize);
 
 
             this.back.addChild(star);
@@ -94,7 +99,7 @@ class StarManager extends GameComponentBase {
     }
 
     generateStarVector = (camera) => {
-        let z = Math.max(40, Math.pow(3, 4) * Math.random());
+        let z = Math.max(45, Math.pow(3, 4) * Math.random());
         z += camera.getPosition().z;
 
         let x = Math.random() * (camera.resolution.x / 2) * (z - camera.getPosition().z) * (Math.random() * 2 > 1 ? 1 : -1);


### PR DESCRIPTION
The starmanager spawn density is now proportional to the width of the window plus the height of the window. Mobile devices should have half of the density to reduce load. While I was here I disabled camera steering for mobile devices. TODO: make steering for mobile devices not bad. Changed stardensity in gameworkin to spawn one star per... unit?